### PR TITLE
Pull GeometryData.zip for UnityGEARS Demo2 during setup

### DIFF
--- a/UnityGEARS/Editor/Assets/Demo2-VirtualConfocalMicroscopy/GeometryData.zip
+++ b/UnityGEARS/Editor/Assets/Demo2-VirtualConfocalMicroscopy/GeometryData.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:030fecd7a6d460fc0db4cebcb1838f2602b63d7e1de76a6b1090997e35605716
-size 110169986

--- a/UnityGEARS/Editor/Assets/Demo2-VirtualConfocalMicroscopy/GeometryData.zip.meta
+++ b/UnityGEARS/Editor/Assets/Demo2-VirtualConfocalMicroscopy/GeometryData.zip.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b5df1870ec7daad4892cfa9ea71ca3a6
-timeCreated: 1503847508
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/UnityGEARS/README.md
+++ b/UnityGEARS/README.md
@@ -1,53 +1,53 @@
 # GEARS in Unity 5
+____
 
 <div align="center">
      <img src="./images/InteractiveViewer.png"/>
 </div>
 
-## Overview
+# Overview
 
-In this instance of GEARS, we provide a platform/workflow to take your data into virtual reality with minimal effort or coding. We show how you can view and interact static snapshots of previously computed simulations as well as adapt existing simulation code to run in the engine in real time. Using free software, commodity hardware, and a few drags & drops, you can hold, manipulate, and examine your atomic structures with your very own hands!
+In these GEARS Demos, we show how you can take your data into virtual reality with minimal effort or coding. View and interact with static snapshots of previously computed simulations as well as adapt existing simulation code to run in the engine in real time. Using free software, commodity hardware, and a few drags & drops, you can hold, manipulate, and examine your atomic structures with your very own hands!
 
-## System Requirements
-* [Windows 10 OS](https://www.microsoft.com/en-us/windows/) (64-bit Version Recommended)
-* [Unity Engine](https://unity3d.com/) (Version 5.6.1f1 Recommended)
+# System Requirements
+* [Windows 10](https://www.microsoft.com/en-us/windows/) x64
+* [Unity Engine](https://unity3d.com/) v5.6.1f1
   * *Note: Be sure to also have Unity account created and logged in to the engine*
-* Virtual Reality Head Mounted Display (only need one)
+* Virtual Reality Head Mounted Display (HMD) of choice. We've only tested with
   1. [HTC Vive](https://www.vive.com/)
-  2. [Oculus Rift](https://www.oculus.com/)
+  1. [Oculus Rift](https://www.oculus.com/)
   * *Note: Respective runtimes and supporting software for the HMDs are also required*
 * For Interactive Demos: [Leap Motion](https://www.leapmotion.com/) attached to front of HMD
 
-## Installation
-The default installation only includes two of the four demos available. The two non-default demos are the Interactive Viewer and the Virtual Confocal Microscopy. Although these demos provide considerable insight on the strengths of Unity GEARS in VR, they utilize large object files to represent our data meshes. Therefore their installation steps may take extra time depending on the speed of your computer. If one chooses not to include them in their installation, then the large object files will simply be left in their respective .zip files, and the corresponding scenes will be empty.
+# Installation
 
-### Setup via Python
-Make sure Python 2 is installed on your Windows 10 machine. From the Windows command prompt run:
+## Requirements
+* Python 2.7, >= 3.6
+* [Pip](https://pip.pypa.io/en/stable/)
+
 ```
-python.exe setup.py
+$ pip install requests
+$ python setup.py
 ```
-If you wish to install the interactive and virtual confocal microscopy demos, include the appropriate flags with the above command like so:
+
+> Note: Demo 2 (virtual confocal microscopy) is rather large. To skip setup for Demo 2, add the flag `--noVCM`
+
+Then run with:
 ```
-python.exe setup.py --interactive --vcm
+$ </path/to/Unity.exe> -projectPath ./Editor
 ```
-* *Note: This script assumes that your version of Unity is stored at "C:\Program Files\Unity\Editor\Unity.exe"*
 
-### Manual Setup
-* If you wish to install the interactive and virtual confocal microscopy demos, unzip the following folders:
-  ```
-  GEARS\UnityGEARS\Editor\Assets\Demo1-DataViewer\GeometryData.zip
-  GEARS\UnityGEARS\Editor\Assets\Demo2-VirtualConfocalMicroscopy\GeometryData.zip
-  ```
+or launch Unity manually and open the `GEARS\UnityGEARS\Editor\` folder.
 
-* Unzip the following file regardless of whether you choose to install the interactive and confocal microscopy demos:
-  ```
-  GEARS\UnityGEARS\Editor\Assets\Leap_Motion_CoreAssets_4.2.1.zip
-  ```
+## Manual Setup (no Python)
 
-* Open up Unity.exe and fill out any necessary login credentials.
-* Select "Open" to open a new project, and navigate to the GEARS\UnrealGEARS\Editor\ folder and select it. Unity will the generate all the necessary project files.
+Unzip [`.\Editor\Assets\Leap_Motion_CoreAssets_4.2.1.zip`](./Editor/Assets/Leap_Motion_CoreAssets_4.2.1.zip)
 
-## How to use
+For Demo #1, unzip [`.\Editor\Assets\Demo1-DataViewer\GeometryData.zip`](./Editor/Assets/Demo1-DataViewer/GeometryData.zip)
+
+For Demo #2, download then unzip this [file](https://drive.google.com/file/d/1E0kapjSMS-4Wl6bqg2ERAD6R8xWKcxtx/view?usp=sharing) to [`.\Editor\Assets\Demo2-VirtualConfocalMicroscopy\GeometryData.zip`](./Editor/Assets/Demo2-VirtualConfocalMicroscopy)
+
+# How to use
  Press the play button on the top of the editor window. Switch between demos using the number pad (0-4). Number pad and demo scene correspondences are as follows:
 <ol start="0">
  <li> Empty Environment </li>

--- a/UnityGEARS/setup.py
+++ b/UnityGEARS/setup.py
@@ -6,13 +6,44 @@ import os
 import os.path
 import subprocess
 import sys
+import requests
+
+# Credit where credit is due: https://stackoverflow.com/a/39225039
+def download_file_from_google_drive(id, destination):
+    def get_confirm_token(response):
+        for key, value in response.cookies.items():
+            if key.startswith('download_warning'):
+                return value
+
+        return None
+
+    def save_response_content(response, destination):
+        CHUNK_SIZE = 32768
+
+        with open(destination, "wb") as f:
+            for chunk in response.iter_content(CHUNK_SIZE):
+                if chunk: # filter out keep-alive new chunks
+                    f.write(chunk)
+
+    URL = "https://docs.google.com/uc?export=download"
+
+    session = requests.Session()
+
+    response = session.get(URL, params = { 'id' : id }, stream = True)
+    token = get_confirm_token(response)
+
+    if token:
+        params = { 'id' : id, 'confirm' : token }
+        response = session.get(URL, params = params, stream = True)
+
+    save_response_content(response, destination)    
 
 #Acquire the current working directory
 currentDir = os.path.dirname(os.path.realpath(__file__))
 
 # Parse Arguments
 parser = argparse.ArgumentParser()
-parser.add_argument("--vcm", help="Adds the Virtual Confocal Microscopy demo to the build", action="store_true")
+parser.add_argument("--noVCM", help="Skips setup for the Virtual Confocal Microscopy (Demo 2)", action="store_true")
 
 args = parser.parse_args();
 
@@ -37,18 +68,15 @@ if not os.path.isdir(leapDir) and not os.path.isfile(leapMeta):
 	leapZip.extractall(assetsPath)
 	leapZip.close()
 
-if args.vcm:
+if not args.noVCM:
     if not os.path.isdir(demo2Dir + geometryDir) and not os.path.isfile(demo2Dir + geometryMeta):
         print('Unzipping Virtual Confocal Microscopy geometry data')
+        geometryDataFileId = '1E0kapjSMS-4Wl6bqg2ERAD6R8xWKcxtx' # hard coded file id
+        download_file_from_google_drive(geometryDataFileId, demo2GeometryZipPath)
         demo2Zip = zipfile.ZipFile(demo2GeometryZipPath, 'r')
         demo2Zip.extractall(demo2Dir)
         demo2Zip.close()
     else:
-        print('Demo 2 Geometry Data already exists. If prefab errors occur, remove folder and meta files, then retry.')
-
-
-# Open Unity
-print('Startin Up Unity')
-subprocess.call(['C:/Program Files/Unity/Editor/Unity.exe', '-projectPath', fullProjectPath])
+        print('Demo 2 Geometry Data already exists. If prefab errors occur, remove folder and meta files, then retry.') 
 
 print('Setup Complete')


### PR DESCRIPTION
Removes the giant GeometryData.zip out of this repository to avoid the cost of maintaining our Git LFS data packets.
